### PR TITLE
Add answer generation with LM Studio and cosine FAISS 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas
+numpy
+sentence-transformers
+faiss-cpu
+openai
+python-dotenv

--- a/src/build_embeddings.py
+++ b/src/build_embeddings.py
@@ -35,9 +35,11 @@ embeddings = model.encode(df["text"].tolist(), show_progress_bar=True)
 # Convert to float32 as required by FAISS
 embeddings = np.array(embeddings).astype("float32")
 
-# Build a simple FAISS index with L2 (Euclidean) distance
-# Note: if we normalize vectors first, L2 ranking becomes equivalent to cosine similarity
-index = faiss.IndexFlatL2(embeddings.shape[1])
+# Normalizing vectors 
+faiss.normalize_L2(embeddings)
+# Build a simple FAISS index with Innner Product for cosine similarity
+dim = embeddings.shape[1]
+index = faiss.IndexFlatIP(dim)
 index.add(embeddings)
 
 # Save the FAISS index to disk so we can reload it later for search

--- a/src/explore_csvs.py
+++ b/src/explore_csvs.py
@@ -1,17 +1,24 @@
+"""
+Quick inspection script for the processed Formula 1 dataset.
+
+This is just to check what the processed file looks like
+before moving on to embeddings and retrieval.
+"""
+
 import pandas as pd
 import os
 
-# Putanja do processed fajla
+# Path to the processed file created by preprocess_data.py
 processed_path = os.path.join("data", "processed", "processed_races.csv")
 
-# Učitavanje
+# Loading the dataset into a pandas DataFrame
 df = pd.read_csv(processed_path)
 
-# Prvih 5 redova
+# Printing the first 5 rows to get a sense of the structure
 print(df.head())
 
-# Vidi kolone
-print("\nKolone:", df.columns.tolist())
+# Show the list of column names
+print("\nColumns:", df.columns.tolist())
 
-# Vidi koliko ima dokumenata
-print("\nBroj redova:", len(df))
+# Show the total number of documents (rows)
+print("\nNumber of documents:", len(df))

--- a/src/preprocess_data.py
+++ b/src/preprocess_data.py
@@ -20,7 +20,7 @@ Output
 raw_folder = "data/raw"
 processed_folder = "data/processed"
 
-# Load the core CSV files we need for a first RAG pass
+# Loading the core CSV files we need for a first RAG pass
 
 
 
@@ -35,18 +35,18 @@ constructors = pd.read_csv(os.path.join(raw_folder, "constructors.csv"))
 # circuits: circuit name, location, country
 circuits = pd.read_csv(os.path.join(raw_folder, "circuits.csv"))
 
-# Join all tables into a single frame of race results with rich context
-# We start from results, then add race info, driver info, constructor info, and circuit info
-# suffixes are applied only when column names collide
-# for example, both races and circuits have a column called name
-# after merges we will have name from races, and name_circuit from circuits
+# Joining all tables into a single DataFrame of race results with rich context
+# Starting from results, then adding race info, driver info, constructor info, and circuit info
+# Applying suffixes only when column names collide
+# For example, both races and circuits have a column called 'name'
+# After merging we will have 'name' from races, and 'name_circuit' from circuits
 results = results.merge(races, on="raceId", how="left", suffixes=("", "_race"))
 results = results.merge(drivers, on="driverId", how="left", suffixes=("", "_driver"))
 results = results.merge(constructors, on="constructorId", how="left", suffixes=("", "_constructor"))
 results = results.merge(circuits, on="circuitId", how="left", suffixes=("", "_circuit"))
 
-# Build a short narrative per driver per race
-# We keep it concise and structured so sentence embeddings work well
+# Building a short narrative per driver per race
+# We are keeping it concise and structured so sentence embeddings work well
 documents = []
 for _, row in results.iterrows():
     # race name comes from races as name
@@ -66,7 +66,7 @@ for _, row in results.iterrows():
         }
     )
 
-# Save the processed dataset that will be embedded in the next step
+# Saving the processed dataset that will be embedded in the next step
 processed_df = pd.DataFrame(documents)
 os.makedirs(processed_folder, exist_ok=True)
 processed_df.to_csv(os.path.join(processed_folder, "processed_races.csv"), index=False)

--- a/src/rag_answer.py
+++ b/src/rag_answer.py
@@ -1,0 +1,150 @@
+import os
+import argparse
+import numpy as np
+import pandas as pd
+import faiss
+from dotenv import load_dotenv
+from openai import OpenAI
+from sentence_transformers import SentenceTransformer
+
+# Setup and config
+load_dotenv()
+
+OPENAI_API_BASE = os.getenv("OPENAI_API_BASE", "http://localhost:1234/v1")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "lm-studio")
+MODEL_NAME = os.getenv("MODEL_NAME", "mistralai/mistral-7b-instruct-v0.3")
+
+PROCESSED_PATH = os.path.join("data", "processed", "processed_races.csv")
+INDEX_PATH = os.path.join("models", "f1_faiss.index")
+EMBED_MODEL_NAME = "all-MiniLM-L6-v2"  # same model used for indexing
+
+client = OpenAI(base_url=OPENAI_API_BASE, api_key=OPENAI_API_KEY)
+embedder = SentenceTransformer(EMBED_MODEL_NAME)
+
+
+# Helpers 
+def load_data_and_index():
+    if not os.path.exists(PROCESSED_PATH):
+        raise FileNotFoundError(
+            f"Missing {PROCESSED_PATH}. Run src/preprocess_data.py first."
+        )
+    if not os.path.exists(INDEX_PATH):
+        raise FileNotFoundError(
+            f"Missing {INDEX_PATH}. Run src/build_embeddings.py first."
+        )
+    df = pd.read_csv(PROCESSED_PATH)
+    index = faiss.read_index(INDEX_PATH)
+    return df, index
+
+
+def embed_query(query: str) -> np.ndarray:
+    vec = embedder.encode([query])
+    vec = np.asarray(vec, dtype = "float32")
+    faiss.normalize_L2(vec)  #normalizing a query vector for cosine search
+    return vec
+
+def retrieve_top_k(df: pd.DataFrame, index: faiss.Index, query: str, k: int = 5):
+    q = embed_query(query)
+    D, I = index.search(q, k)
+    hits = []
+    for idx, score in zip(I[0], D[0]):
+        if 0 <= idx < len(df):
+            hits.append({"idx": int(idx), "score": float(score), "text": df.iloc[idx]["text"]})
+    return hits
+
+
+def maybe_prioritize_winner(hits, query_lower: str):
+    """
+    If the question asks 'who won', keep only entries with 'Finished position: 1'.
+    If none found, fall back to original hits.
+    """
+    if "who won" in query_lower:
+        winners = []
+        for h in hits:
+            t = h["text"]
+            if "Finished position: 1" in t or "Finished position: 1," in t:
+                winners.append(h)
+        return winners if winners else hits
+    return hits
+
+
+
+def trim_contexts(contexts: list[str], max_chars: int = 2200) -> list[str]:
+    """
+    Keep adding snippets until we hit a soft character budget.
+    Helps local models keep prompt small & fast.
+    """
+    out, total = [], 0
+    for c in contexts:
+        if total + len(c) + 4 > max_chars:
+            break
+        out.append(c)
+        total += len(c) + 4
+    return out
+
+
+def build_user_prompt(question: str, contexts: list[str]) -> str:
+    """
+    LM Studio's Mistral template supports only `user` and `assistant`.
+    We put instructions + context + question in a single user message.
+    """
+    bullet_context = "\n".join(f"- {c}" for c in contexts)
+    return (
+        "You answer Formula 1 questions strictly using the provided CONTEXT.\n"
+        "Rules:\n"
+        "1) Use ONLY facts present in CONTEXT. Do not invent.\n"
+        "2) If the answer is not in CONTEXT, reply exactly: \"I don't know based on the provided context.\"\n"
+        "3) Be concise and precise.\n"
+        "4) If asking for a race winner, return just the winner's full name and team.\n\n"
+        f"CONTEXT:\n{bullet_context}\n\n"
+        f"QUESTION:\n{question}\n\n"
+        "Answer:"
+    )
+
+
+def generate_answer(question: str, contexts: list[str], temperature: float = 0.0, max_tokens: int = 256) -> str:
+    prompt = build_user_prompt(question, contexts)
+    resp = client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+    return resp.choices[0].message.content.strip()
+
+
+# CLI 
+def main():
+    parser = argparse.ArgumentParser(description="Retrieve + generate an answer using a local LLM via LM Studio.")
+    parser.add_argument("--question", "-q", type=str, required=False,
+                        help='e.g., "Who won the 2008 Australian Grand Prix?"')
+    parser.add_argument("--top_k", type=int, default=10, help="How many snippets to pass as context.")
+    parser.add_argument("--max_context_chars", type=int, default=2200, help="Soft cap on context size.")
+    args = parser.parse_args()
+
+    question = args.question or input("Enter your question: ").strip()
+    df, index = load_data_and_index()
+
+    # Retrieve
+    raw_hits = retrieve_top_k(df, index, question, k=args.top_k)
+    hits = maybe_prioritize_winner(raw_hits, question.lower())
+
+    # Build context
+    contexts = [h["text"] for h in hits]
+    contexts = trim_contexts(contexts, max_chars=args.max_context_chars)
+
+    # Generate
+    answer = generate_answer(question, contexts, temperature=0.0, max_tokens=256)
+
+    # Output
+    print("\n=== QUESTION ===")
+    print(question)
+    print("\n=== ANSWER ===")
+    print(answer)
+    print("\n=== SOURCES (Top retrieved) ===")
+    for i, h in enumerate(hits, 1):
+        print(f"{i:>2}. [score {h['score']:.4f}] {h['text']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/search_demo.py
+++ b/src/search_demo.py
@@ -4,30 +4,31 @@ import numpy as np
 import faiss
 from sentence_transformers import SentenceTransformer
 
-# Folders
+# Paths to processed data and the FAISS index
 processed_folder = "data/processed"
 models_folder = "models"
 
-# Učitaj processed fajl
+# Load the processed dataset with race, driver, and constructor text
 df = pd.read_csv(os.path.join(processed_folder, "processed_races.csv"))
 
-# Učitaj FAISS index
+# Load the pre-built FAISS index
 index = faiss.read_index(os.path.join(models_folder, "f1_faiss.index"))
 
-# Učitaj model za embedding
+# Load the same embedding model used during indexing
 model = SentenceTransformer("all-MiniLM-L6-v2")
 
-# Primer upita
+# Example query to test the search
 query = "Who won the 2008 Australian Grand Prix?"
 print(f"Query: {query}")
 
-# Kreiraj embedding upita
+# Convert the query into an embedding vector
 query_embedding = model.encode([query])
 query_embedding = np.array(query_embedding).astype("float32")
 
-# Pretraga u FAISS (vrati top 5)
+# Search the FAISS index and return the top 5 closest matches
 D, I = index.search(query_embedding, k=5)
 
+# Print the results with their similarity scores
 print("\nTop results:")
 for idx, score in zip(I[0], D[0]):
     print(f"Score: {score:.4f} | Text: {df.iloc[idx]['text']}")

--- a/src/test_lmstudio.py
+++ b/src/test_lmstudio.py
@@ -1,0 +1,28 @@
+import os
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+BASE = os.getenv("OPENAI_API_BASE", "http://localhost:1234/v1")
+KEY  = os.getenv("OPENAI_API_KEY", "lm-studio")
+MODEL = os.getenv("MODEL_NAME", "mistralai/mistral-7b-instruct-v0.3")
+
+client = OpenAI(base_url=BASE, api_key=KEY)
+
+messages = [
+    {"role": "user", "content": "You are a helpful assistant. Be concise. Say hi in one short sentence."}
+]
+
+
+
+try:
+    resp = client.chat.completions.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0.2,
+        max_tokens=50,
+    )
+    print("RESPONSE:\n", resp.choices[0].message.content.strip())
+except Exception as e:
+    print("ERROR:", repr(e))


### PR DESCRIPTION
Added rag_answer.py for retrieval and answer generation using LM Studio.
Implemented simple logic to prioritize winners when the question is “who won”.
Switched the FAISS index to cosine similarity (normalized vectors + IndexFlatIP).
Created test_lmstudio.py for local API testing.
Added a requirements.txt with all dependencies.
Data and models (data/, models/) are still excluded via .gitignore.
